### PR TITLE
Correct shiftUpperValue() for d4 (Issue #6)

### DIFF
--- a/lib/dice.js
+++ b/lib/dice.js
@@ -206,6 +206,18 @@ class DiceObject {
 
             geometry.faces[i].materialIndex = materialIndex + 1;
         }
+        if (this.values == 4 && toValue != fromValue) {
+            // to shift faces on a d4, we need to alter faceTexts and recreate the textures from it
+            let num = toValue - fromValue;
+            if (num < 0) num += 4;
+            this.faceTexts = [
+                [[], [0, 0, 0], [2, 4, 3], [1, 3, 4], [2, 1, 4], [1, 2, 3]],
+                [[], [0, 0, 0], [2, 3, 4], [3, 1, 4], [2, 4, 1], [3, 2, 1]],
+                [[], [0, 0, 0], [4, 3, 2], [3, 4, 1], [4, 2, 1], [3, 1, 2]],
+                [[], [0, 0, 0], [4, 2, 3], [1, 4, 3], [4, 1, 2], [1, 3, 2]]
+            ][num];
+            this.object.material = this.getMaterials();
+        }
 
         this.object.geometry = geometry;
     }


### PR DESCRIPTION
Part of shift_dice_faces() from the original dice.js had not been brought into this adaptation.  I've attempted to port it over.  It seems to work in my tests, but I am not 100% confident given I haven't fully understood the underlying code.